### PR TITLE
Support additional arguments for OpenRouter and Anthropic models

### DIFF
--- a/packages/python/src/mainframe_orchestra/llm.py
+++ b/packages/python/src/mainframe_orchestra/llm.py
@@ -790,9 +790,12 @@ class OpenrouterModels:
         api_key = config.validate_api_key("OPENROUTER_API_KEY")
 
         # Handle o1 model message transformations if needed
-        additional_params = None
+        additional_params = {}
         if model.endswith("o1-mini") or model.endswith("o1-preview"):
             messages = OpenaiModels._transform_o1_messages(messages, require_json_output)
+        
+        # Add any extra kwargs to additional_params
+        additional_params.update(extra_kwargs)
 
         return await OpenAICompatibleProvider.send_request(
             model=model,
@@ -805,8 +808,7 @@ class OpenrouterModels:
             require_json_output=require_json_output,
             messages=messages,
             stream=stream,
-            additional_params=additional_params,
-            **extra_kwargs,
+            additional_params=additional_params if additional_params else None,
         )
 
     @staticmethod

--- a/packages/python/src/mainframe_orchestra/llm.py
+++ b/packages/python/src/mainframe_orchestra/llm.py
@@ -769,8 +769,6 @@ class AnthropicModels:
                 for content_part in response.content:
                     if hasattr(content_part, 'type') and content_part.type == "text":
                         content += content_part.text
-                    elif hasattr(content_part, 'text'):  # Fallback for older format
-                        content += content_part.text
             
             spinner.succeed("Request completed")
             # For non-JSON responses, keep original formatting but make single line

--- a/packages/python/src/mainframe_orchestra/llm.py
+++ b/packages/python/src/mainframe_orchestra/llm.py
@@ -215,7 +215,29 @@ class OpenAICompatibleProvider:
 
             # Add any additional parameters
             if additional_params:
-                request_params.update(additional_params)
+                # Split additional_params into supported SDK params and extra_body params
+                supported_openai_params = {
+                    'frequency_penalty', 'function_call', 'functions', 'logit_bias', 
+                    'logprobs', 'max_tokens', 'max_completion_tokens', 'n', 'parallel_tool_calls',
+                    'presence_penalty', 'response_format', 'seed', 'stop', 'stream',
+                    'temperature', 'tool_choice', 'tools', 'top_logprobs', 'top_p', 'user'
+                }
+                
+                sdk_params = {}
+                extra_body_params = {}
+                
+                for key, value in additional_params.items():
+                    if key in supported_openai_params:
+                        sdk_params[key] = value
+                    else:
+                        extra_body_params[key] = value
+                
+                # Add SDK-supported parameters directly
+                request_params.update(sdk_params)
+                
+                # Add unsupported parameters to extra_body
+                if extra_body_params:
+                    request_params['extra_body'] = extra_body_params
 
             # Log request details
             logger.debug(

--- a/packages/python/src/mainframe_orchestra/llm.py
+++ b/packages/python/src/mainframe_orchestra/llm.py
@@ -758,6 +758,7 @@ class OpenrouterModels:
         require_json_output: bool = False,
         messages: Optional[List[Dict[str, str]]] = None,
         stream: bool = False,
+        **extra_kwargs,
     ) -> Union[Tuple[str, Optional[Exception]], AsyncGenerator[str, None]]:
         """
         Sends a request to OpenRouter models.
@@ -805,10 +806,11 @@ class OpenrouterModels:
             messages=messages,
             stream=stream,
             additional_params=additional_params,
+            **extra_kwargs,
         )
 
     @staticmethod
-    def custom_model(model_name: str):
+    def custom_model(model_name: str, **static_kwargs):
         async def wrapper(
             image_data: Union[List[str], str, None] = None,
             temperature: float = 0.7,
@@ -816,7 +818,9 @@ class OpenrouterModels:
             require_json_output: bool = False,
             messages: Optional[List[Dict[str, str]]] = None,
             stream: bool = False,
+            **call_kwargs,
         ) -> Union[Tuple[str, Optional[Exception]], Iterator[str]]:
+            merged_kwargs = {**static_kwargs, **call_kwargs}
             return await OpenrouterModels.send_openrouter_request(
                 model=model_name,
                 image_data=image_data,
@@ -825,6 +829,7 @@ class OpenrouterModels:
                 require_json_output=require_json_output,
                 messages=messages,
                 stream=stream,
+                **merged_kwargs,
             )
 
         return wrapper


### PR DESCRIPTION
support additional arguments eg `tools` in `OpenrouterModels.custom_model` and `AnthropicModels.custom_model` model methods, which are forwarded appropriately to OpenAI and Anthropic SDKs
- SDK supported args passed directly on top level
- non-standard args (like OpenRouter `provider`) in `extra_body`

More robust content part handling in Anthropic model calls - properly handle array of parts, and extract only text type contents, log the rest (as eg it will get server tools used as response content parts)